### PR TITLE
Enable kodiak bot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,14 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "local>anguslees/renovate-config"
+    ],
+    "automergeType": "pr",
+    "packageRules": [
+        {
+            "description": "Automerge trivial updates",
+            "matchUpdateTypes": ["patch", "digest", "lockFileMaintenance"],
+            "automerge": false,
+            "addLabels": ["automerge"]
+        }
     ]
 }

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,1 @@
+version = 1


### PR DESCRIPTION
Default kodiak setup:  Will merge on `automerge` label.

Teach renovatebot to use the automerge label.